### PR TITLE
Prevent veterinarians from changing permissions

### DIFF
--- a/app/controllers/veterinarians_controller.rb
+++ b/app/controllers/veterinarians_controller.rb
@@ -30,7 +30,8 @@ class VeterinariansController < ApplicationController
 
   def update
     respond_to do |format|
-      if @veterinarian.update(veterinarian_params)
+      #except admin parameter when updating veterinarian
+      if @veterinarian.update(veterinarian_params.except(:admin))
         format.html { redirect_to @veterinarian, notice: 'Veterinarian was successfully updated.' }
         format.json { render :show, status: :ok, location: @veterinarian }
       else


### PR DESCRIPTION
### How the Veterinarian Assumed Admin Role

The HTML form used to update veterinarian information had a disabled attribute on the admin checkbox. This disabled setting visually made it look like you couldn't change the admin status. However, this restriction wasn't properly enforced on the server side. By changing the HTML code using browser developer tools, veterinarians were able to remove the disabled attribute and modify their admin permissions.

### Prevent veterinarians from changing their permissions
In the VeterinariansController's update action, added a security measure to prevent veterinarians from changing their permissions. Specifically, the admin parameter is now excluded when updating veterinarian information. Modified the update action to exclude the admin parameter from the veterinarian_params. This change ensures that any attempt to modify the admin permissions through the update action is ignored.