### PR TITLE
prenet hard deletion of animals and veterinarians

### DIFF
--- a/app/controllers/animals_controller.rb
+++ b/app/controllers/animals_controller.rb
@@ -3,7 +3,7 @@ class AnimalsController < ApplicationController
   rescue_from ActiveRecord::InvalidForeignKey, with: :invalid_foreign_key
 
   def index
-    @animals = Animal.all
+    @animals = Animal.where(deleted_at: nil)
   end
 
   def show; end
@@ -33,10 +33,11 @@ class AnimalsController < ApplicationController
   end
 
   def destroy
-    if @animal.destroy
-      redirect_to animals_path, notice: 'Animal was successfully destroyed'
+    #use soft delete function to delete the animal
+    if @animal.soft_delete
+      redirect_to animals_path, notice: 'Animal was marked as deleted'
     else
-      redirect_to animals_path, error: 'Animal could not be destroyed'
+      redirect_to animals_path, error: 'Animal could not be deleted'
     end
   end
 

--- a/app/controllers/veterinarians_controller.rb
+++ b/app/controllers/veterinarians_controller.rb
@@ -3,7 +3,7 @@ class VeterinariansController < ApplicationController
   rescue_from ActiveRecord::InvalidForeignKey, with: :invalid_foreign_key
 
   def index
-    @veterinarians = Veterinarian.all
+    @veterinarians = Veterinarian.where(deleted_at: nil)
   end
 
   def show; end
@@ -41,9 +41,9 @@ class VeterinariansController < ApplicationController
   end
 
   def destroy
-    @veterinarian.destroy
+    @veterinarian.soft_delete
     respond_to do |format|
-      format.html { redirect_to veterinarians_url, notice: 'Veterinarian was successfully destroyed.' }
+      format.html { redirect_to veterinarians_url, notice: 'Veterinarian was successfully soft deleted.' }
       format.json { head :no_content }
     end
   end

--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -1,3 +1,7 @@
 class Animal < ApplicationRecord
   has_many :tests, dependent: :restrict_with_exception
+
+  def soft_delete
+    update(deleted_at: Time.now)
+  end
 end

--- a/app/models/veterinarian.rb
+++ b/app/models/veterinarian.rb
@@ -1,3 +1,7 @@
 class Veterinarian < ApplicationRecord
   has_many :tests, dependent: :restrict_with_exception
+
+  def soft_delete
+    update(deleted_at: Time.now)
+  end
 end

--- a/db/migrate/20240305023732_add_deleted_at_to_animals.rb
+++ b/db/migrate/20240305023732_add_deleted_at_to_animals.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToAnimals < ActiveRecord::Migration[6.1]
+  def change
+    add_column :animals, :deleted_at, :datetime
+    add_index :animals, :deleted_at
+  end
+end

--- a/db/migrate/20240305025724_add_deleted_at_to_veterinarian.rb
+++ b/db/migrate/20240305025724_add_deleted_at_to_veterinarian.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToVeterinarian < ActiveRecord::Migration[6.1]
+  def change
+    add_column :veterinarians, :deleted_at, :datetime
+    add_index :veterinarians, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_21_141910) do
+ActiveRecord::Schema.define(version: 2024_03_05_025724) do
 
   create_table "animals", force: :cascade do |t|
     t.string "unique_tag"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2022_11_21_141910) do
     t.date "birth_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_animals_on_deleted_at"
   end
 
   create_table "tests", force: :cascade do |t|
@@ -40,6 +42,8 @@ ActiveRecord::Schema.define(version: 2022_11_21_141910) do
     t.string "number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_veterinarians_on_deleted_at"
   end
 
   add_foreign_key "tests", "animals"


### PR DESCRIPTION
### Changes Made
- Added a deleted_at column to the Animal model to mark animals as soft-deleted.
- Added a deleted_at column to the Veterinarian model to mark veterinarians as soft-deleted.
- Created a soft_delete method in the Animal and Veterinary models to update the deleted_at timestamp.
- Updated the destroy action in the AnimalsController and VeterinariansController to use the soft_delete method instead of the default destroy method.
- Modified the index action to exclude soft-deleted animals from the listing.

### Verification Steps
1. Create a new animal and delete using the "Destroy" button.
2. Verify that the animal is no longer displayed in the animals listing page.
3. Check the database to confirm that the deleted_at timestamp for the animal has been set.
4. Repeat the same steps for Veterinarians as well. 

